### PR TITLE
Made godrays compatible with motion smoothing

### DIFF
--- a/Code/Effects/HexagonalGodray.cs
+++ b/Code/Effects/HexagonalGodray.cs
@@ -139,7 +139,7 @@ public class HexagonalGodray : Backdrop
             float num3 = -32f + Mod(rays[i].Y - level.Camera.Y * 0.9f, 244f + yExtend);
             float angle = rays[i].angle;
             int length = rays[i].length;
-            Vector2 vector3 = new Vector2((int)num2, (int)num3);
+            Vector2 vector3 = Calc.Floor(new Vector2(num2, num3));
 
             Color color = Color.White;
             if (hsvBlending)

--- a/Code/Effects/StarGodray.cs
+++ b/Code/Effects/StarGodray.cs
@@ -147,7 +147,7 @@ public class StarGodray : Backdrop
             float num2 = -32f + Mod(rays[i].X - level.Camera.X * 0.9f, 384f + xExtend);
             float num3 = -32f + Mod(rays[i].Y - level.Camera.Y * 0.9f, 244f + yExtend);
             int length = rays[i].length;
-            Vector2 vector3 = new Vector2((int)num2, (int)num3);
+            Vector2 vector3 = Calc.Floor(new Vector2(num2, num3));
 
             Color color = Color.White;
             if (hsvBlending)


### PR DESCRIPTION
This maintains the exact behavior of hexagonal and star godrays while adding compatibility with motion smoothing so that they don't jitter in its high quality mode.